### PR TITLE
Test perl versions 5.24 and 5.26

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ language: perl
 perl:
   - "5.30"
   - "5.28"
+  - "5.26"
+  - "5.24"
 env:
   - TRAVIS_RUST_VERSION=stable
   - TRAVIS_RUST_VERSION=beta


### PR DESCRIPTION
Debian stretch ships with perl version 5.24, and would be helpful to include it (plus 5.26 for giggles) in the CI testing. Does this seem reasonable? I don't see any need to restore testing for `5.*-shrplib`, but these would be helpful :)