### PR TITLE
Fix compilation bug

### DIFF
--- a/perlxs_derive/Cargo.toml
+++ b/perlxs_derive/Cargo.toml
@@ -11,5 +11,4 @@ proc-macro = true
 [dependencies]
 syn = "0.11.11"
 quote = "0.3.15"
-perl-xs = { path = "../" }
 perlxs_derive_internals = { path = "../perlxs_derive_internals" }

--- a/perlxs_derive/src/lib.rs
+++ b/perlxs_derive/src/lib.rs
@@ -1,4 +1,3 @@
-extern crate perl_xs;
 extern crate proc_macro;
 #[macro_use]
 extern crate quote;


### PR DESCRIPTION
perlxs_derive included dependency on perl_xs, which, on later versions
of rustc caused the compiled proc macro library to require perl's
symbols. Since the proc macro is loaded by the rustc and not perl,
these symbols could not be resolved and compilation failed.

Fix the problem by removing the unnecessary import.